### PR TITLE
Add parameter name to cal.parameters dataframe

### DIFF
--- a/ttim/fit.py
+++ b/ttim/fit.py
@@ -149,6 +149,7 @@ class Calibrate:
             "pmin": float(pmin),
             "pmax": float(pmax),
             "initial": float(initial),
+            "params": name,
             "inhoms": aq if inhoms is not None else None,
             "parray": plist,
         }


### PR DESCRIPTION
I would suggest it is usefull to add a column with the parameter name (e.g.: 'kaq') to the cal.parameters dataframe. 

Otherwise we would have to extract it from the row index value if we want to select a specific value from the dataframe.